### PR TITLE
v0.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you are installing a CUDA capable BIONIC wheel (i.e. not CPU), first ensure y
     
     For example, if we wanted to install the latest version of BIONIC to run on the CPU on a Linux system, we would run
     
-       $ pip install https://github.com/bowang-lab/BIONIC/releases/download/v0.2.5/bionic_model-0.2.5+cpu-cp38-cp38-linux_x86_64.whl
+       $ pip install https://github.com/bowang-lab/BIONIC/releases/download/v0.2.6/bionic_model-0.2.6+cpu-cp38-cp38-linux_x86_64.whl
 
     **NOTE:** There is a [known bug](https://github.com/pypa/pip/issues/7626) in certain versions of `pip` which may result in a `No matching distribution` error. If this occurs, install `pip==19.3.1` and try again.
 
@@ -118,7 +118,7 @@ The configuration keys are as follows:
 
 Argument | Default | Description
 --- | :---: | ---
-`net_names` | `null` | Filepaths of input networks. By specifying `"*"` after the path, BIONIC will integrate all networks in the directory.
+`net_names` | `null` | List of filepaths of input networks. If a string is used instead with a `"*"` after the path, BIONIC will integrate all networks in the corresponding directory.
 `label_names` | `null` | Filepaths of node label JSON files. An example node label file can be found [here](https://github.com/bowang-lab/BIONIC/blob/master/bionic/inputs/yeast_IntAct_complex_labels.json).
 `out_name` | config file path | Path to prepend to all output files. If not specified it will be the path of the config file. `out_name` takes the format `path/to/output` where `output` is an extensionless output file name.
 `delimiter` | `" "` | Delimiter for input network files.

--- a/bionic/tests/utils/test_config_parser.py
+++ b/bionic/tests/utils/test_config_parser.py
@@ -45,7 +45,7 @@ class TestConfigParser:
         mock_config_asterisk_names["net_names"] = "*"
         cp = ConfigParser(mock_config_asterisk_names)
         params = cp.parse()
-        assert isinstance(params.net_names, list)
+        assert isinstance(params.net_names, list) and len(params.net_names)
 
     def test_config_fields_replace_defaults(self):
         cp = ConfigParser(mock_config)

--- a/bionic/utils/config_parser.py
+++ b/bionic/utils/config_parser.py
@@ -119,7 +119,7 @@ class ConfigParser(DefaultConfig):
 
     def _resolve_asterisk_path(self, path: Path) -> List[Path]:
         directory = path.parent
-        return [p for p in directory.iterdir() if p.is_dir()]
+        return [p for p in directory.iterdir() if not p.is_dir()]
 
     def _get_param(self, param: str, default: Any) -> Any:
         if param in self.config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bionic-model"
-version = "0.2.5"
+version = "0.2.6"
 description = "Biological network integration using convolutions."
 authors = ["Duncan Forster <duncan.forster@mail.utoronto.ca>"]
 license = "MIT"


### PR DESCRIPTION
- Fix bug where an asterisk path value to `net_names` didn't work
- Update [`test_asterisk_in_net_names_fetches_filenames`](https://github.com/bowang-lab/BIONIC/blob/807aadbeb18eb367dc31b3dfa4e6b0638897bfe3/bionic/tests/utils/test_config_parser.py#L43) to test for empty list
- Update documentation to make it clearer that a string can be passed to `net_name` if it has an asterisk on the end